### PR TITLE
Provide an option to specify command with

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The following options can be passed to Guard::PHPUnit:
 :cli => '--colors'            # The options passed to the phpunit command
                               # when running the tests.
                               # default: nil
+
+:command => "./bin/phpunit"   # specify alternative phpunit location
+                              # that is not on the path.
+                              # Useful if running phpunit from composer
 ```
 
 Development

--- a/lib/guard/phpunit/runner.rb
+++ b/lib/guard/phpunit/runner.rb
@@ -172,9 +172,12 @@ module Guard
         #
         def phpunit_command(path, options)
           formatter_path = File.join( File.dirname(__FILE__), 'formatters', 'PHPUnit-Progress')
+          
+          command = "phpunit"
+          command = options[:command] if options[:command]
 
           cmd_parts = []
-          cmd_parts << "phpunit"
+          cmd_parts << command
           cmd_parts << "--include-path #{formatter_path}"
           cmd_parts << "--printer PHPUnit_Extensions_Progress_ResultPrinter"
           cmd_parts << options[:cli] if options[:cli]

--- a/spec/guard/phpunit/runner_spec.rb
+++ b/spec/guard/phpunit/runner_spec.rb
@@ -50,6 +50,14 @@ describe Guard::PHPUnit::Runner do
         subject.run( ['tests'] )
       end
 
+      it 'runs phpunit tests with provided command' do
+        formatter_path = @project_path.join('lib', 'guard', 'phpunit', 'formatters', 'PHPUnit-Progress')
+        subject.should_receive(:execute_command).with(
+          %r{^/usr/local/bin/phpunit --include-path #{formatter_path} --printer PHPUnit_Extensions_Progress_ResultPrinter .+$}
+        ).and_return(true)
+        subject.run( ['tests'] , {:command => '/usr/local/bin/phpunit'} )
+      end
+
       it 'prints the tests output to the console' do
           output = load_phpunit_output('passing')
           subject.stub(:notify_start)


### PR DESCRIPTION
Since phpunit started publishing packages over composer I've switched to using this method of running phpunit rather than installing globally via pear. 

This change defaults to the globally installed phpunit but allows the user to specify an alternative command to run.
